### PR TITLE
Secure API routes with auth and encryption

### DIFF
--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -1,0 +1,6 @@
+# Key Management Guidelines
+
+- Store the `AUTH_TOKEN` and `CONVERSATION_ENCRYPTION_KEY` in environment variables.
+- Rotate keys regularly and whenever compromise is suspected.
+- Never commit keys to source control. Use secret managers or deployment environment configs.
+- Limit access to keys to only the services that require them.

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
   globals: {
     'ts-jest': {

--- a/web/src/app/api/auth.test.ts
+++ b/web/src/app/api/auth.test.ts
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+import { POST as detectLoop } from './detect-loop/route';
+
+describe('API authentication', () => {
+  it('rejects requests without valid token', async () => {
+    const req = new Request('http://example.com', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'test' }),
+    });
+    const res = await detectLoop(req as any);
+    expect(res.status).toBe(401);
+  });
+});

--- a/web/src/app/api/detect-loop/route.ts
+++ b/web/src/app/api/detect-loop/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { Configuration, OpenAIApi } from "openai";
+import { requireAuth } from "@/lib/auth";
 
 const config = new Configuration({
   apiKey: process.env.NEXT_PUBLIC_AZURE_OPENAI_KEY,
@@ -9,6 +10,9 @@ const config = new Configuration({
 const openai = new OpenAIApi(config);
 
 export async function POST(req: Request) {
+  const unauthorized = requireAuth(req);
+  if (unauthorized) return unauthorized;
+
   try {
     const { text } = await req.json();
     

--- a/web/src/app/api/get-advice/route.ts
+++ b/web/src/app/api/get-advice/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { Configuration, OpenAIApi } from "openai";
+import { requireAuth } from "@/lib/auth";
 
 const config = new Configuration({
   apiKey: process.env.NEXT_PUBLIC_AZURE_OPENAI_KEY,
@@ -9,6 +10,9 @@ const config = new Configuration({
 const openai = new OpenAIApi(config);
 
 export async function POST(req: Request) {
+  const unauthorized = requireAuth(req);
+  if (unauthorized) return unauthorized;
+
   try {
     const { details } = await req.json();
     

--- a/web/src/app/api/memory/[fileName]/route.ts
+++ b/web/src/app/api/memory/[fileName]/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import { requireAuth } from '@/lib/auth';
+import { encrypt, decrypt } from '@/lib/encryption';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: { fileName: string } }
 ) {
+  const unauthorized = requireAuth(request);
+  if (unauthorized) return unauthorized;
+
   const fileName = params.fileName;
   let filePath = path.join(process.cwd(), '../memory-bank', `${fileName}.md`);
   
@@ -18,9 +23,31 @@ export async function GET(
   
   try {
     const fileContent = fs.readFileSync(filePath, 'utf8');
-    return NextResponse.json({ content: fileContent });
+    const key = process.env.CONVERSATION_ENCRYPTION_KEY || '';
+    const content = key ? decrypt(fileContent, key) : fileContent;
+    return NextResponse.json({ content });
   } catch (error) {
     console.error('Error reading file:', error);
     return NextResponse.json({ error: 'File not found' }, { status: 404 });
   }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { fileName: string } }
+) {
+  const unauthorized = requireAuth(request);
+  if (unauthorized) return unauthorized;
+
+  const { content } = await request.json();
+  const fileName = params.fileName;
+  let filePath = path.join(process.cwd(), '../memory-bank', `${fileName}.md`);
+  if (fileName === '.clinerules') {
+    filePath = path.join(process.cwd(), '../memory-bank', fileName);
+  }
+
+  const key = process.env.CONVERSATION_ENCRYPTION_KEY || '';
+  const data = key ? encrypt(content, key) : content;
+  fs.writeFileSync(filePath, data, 'utf8');
+  return NextResponse.json({ status: 'saved' });
 }

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -1,0 +1,15 @@
+export default function PrivacyPage() {
+  return (
+    <div className="p-8 prose">
+      <h1>Privacy Policy</h1>
+      <p>
+        UICare stores conversation data encrypted on the server using a secret key. This data is used solely to provide the
+        requested services and is never shared with third parties.
+      </p>
+      <p>
+        Authentication tokens are required to access API routes. Keep these credentials secure and rotate them regularly. For
+        more details on managing encryption keys, see our documentation.
+      </p>
+    </div>
+  );
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Simple bearer token authentication.
+ * Expects `Authorization: Bearer <token>` header where token matches `AUTH_TOKEN` env var.
+ */
+export function requireAuth(req: Request): NextResponse | null {
+  const expected = process.env.AUTH_TOKEN;
+  const auth = req.headers.get('authorization');
+  if (!expected || auth !== `Bearer ${expected}`) {
+    return new NextResponse(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return null;
+}

--- a/web/src/lib/encryption.test.ts
+++ b/web/src/lib/encryption.test.ts
@@ -1,0 +1,10 @@
+/** @jest-environment node */
+import { encrypt, decrypt } from './encryption';
+
+test('encrypts and decrypts data', () => {
+  const key = 'test-key';
+  const text = 'secret message';
+  const enc = encrypt(text, key);
+  const dec = decrypt(enc, key);
+  expect(dec).toBe(text);
+});

--- a/web/src/lib/encryption.ts
+++ b/web/src/lib/encryption.ts
@@ -1,0 +1,25 @@
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+
+function getKey(key: string): Buffer {
+  return createHash('sha256').update(key).digest();
+}
+
+export function encrypt(plain: string, key: string): string {
+  const iv = randomBytes(16);
+  const cipher = createCipheriv(ALGORITHM, getKey(key), iv);
+  let encrypted = cipher.update(plain, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const tag = cipher.getAuthTag().toString('hex');
+  return `${iv.toString('hex')}:${tag}:${encrypted}`;
+}
+
+export function decrypt(payload: string, key: string): string {
+  const [ivHex, tagHex, data] = payload.split(':');
+  const decipher = createDecipheriv(ALGORITHM, getKey(key), Buffer.from(ivHex, 'hex'));
+  decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+  let decrypted = decipher.update(data, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}


### PR DESCRIPTION
## Summary
- require bearer token authentication for API routes
- encrypt/decrypt stored conversation files with server-side key and document key management
- add privacy policy page outlining data handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46f2b7dbc8320afe4142754f9aaee