### PR TITLE
Add risk assessment and crisis escalation workflow

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
   globals: {
     'ts-jest': {

--- a/web/src/app/__tests__/riskEscalation.test.tsx
+++ b/web/src/app/__tests__/riskEscalation.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Home from '../page';
+import { assessRisk } from '../../lib/riskService';
+import { detectLoop, getAdvice } from '../../lib/aiService';
+
+jest.mock('../../lib/riskService');
+jest.mock('../../lib/aiService');
+
+const mockedAssessRisk = assessRisk as jest.Mock;
+const mockedDetectLoop = detectLoop as jest.Mock;
+const mockedGetAdvice = getAdvice as jest.Mock;
+
+describe('risk escalation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows crisis resources when risk is high', async () => {
+    mockedAssessRisk.mockResolvedValue({ score: 0.95 });
+
+    render(<Home />);
+    fireEvent.change(screen.getByLabelText('Work text'), { target: { value: 'test' } });
+    fireEvent.click(screen.getByLabelText('Check for loop'));
+
+    expect(await screen.findByText(/Suicide & Crisis Lifeline/i)).toBeInTheDocument();
+    expect(mockedDetectLoop).not.toHaveBeenCalled();
+  });
+
+  it('continues with advice when risk is low', async () => {
+    mockedAssessRisk.mockResolvedValue({ score: 0.1 });
+    mockedDetectLoop.mockResolvedValue({ loopDetected: true, details: 'details' });
+    mockedGetAdvice.mockResolvedValue(['step1']);
+
+    render(<Home />);
+    fireEvent.change(screen.getByLabelText('Work text'), { target: { value: 'test' } });
+    fireEvent.click(screen.getByLabelText('Check for loop'));
+
+    expect(await screen.findByText('step1')).toBeInTheDocument();
+    expect(screen.queryByText(/Suicide & Crisis Lifeline/i)).toBeNull();
+  });
+});

--- a/web/src/app/api/assess-risk/route.ts
+++ b/web/src/app/api/assess-risk/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { Configuration, OpenAIApi } from "openai";
+import fs from "fs";
+import path from "path";
+
+const config = new Configuration({
+  apiKey: process.env.NEXT_PUBLIC_AZURE_OPENAI_KEY,
+  basePath: process.env.NEXT_PUBLIC_AZURE_OPENAI_ENDPOINT + "/openai/deployments/gpt-4",
+});
+
+const openai = new OpenAIApi(config);
+const logPath = path.join(process.cwd(), "risk-stats.log");
+
+export async function POST(req: Request) {
+  try {
+    const { text } = await req.json();
+
+    const completion = await openai.createChatCompletion({
+      model: "gpt-4",
+      messages: [
+        {
+          role: "system",
+          content:
+            "Assess the following text for signs of mental health crisis. Respond with JSON {\"score\": number} where score is between 0 and 1.",
+        },
+        { role: "user", content: text },
+      ],
+    });
+
+    const result = completion.data.choices[0]?.message?.content || "{\"score\":0}";
+    const { score } = JSON.parse(result);
+
+    // Log anonymized risk statistics
+    const entry = { timestamp: new Date().toISOString(), score };
+    fs.appendFileSync(logPath, JSON.stringify(entry) + "\n");
+
+    return NextResponse.json({ score });
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to assess risk" }, { status: 500 });
+  }
+}

--- a/web/src/lib/riskService.ts
+++ b/web/src/lib/riskService.ts
@@ -1,0 +1,15 @@
+export async function assessRisk(text: string) {
+  const response = await fetch("/api/assess-risk", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ text }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to assess risk");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- introduce `assessRisk` client helper and `/api/assess-risk` endpoint backed by OpenAI
- check risk scores before loop detection and show crisis resources when risk is high
- log anonymized risk scores for future model refinement
- add tests for safe escalation and low-risk handling

## Testing
- `npm test --workspace web`

------
https://chatgpt.com/codex/tasks/task_e_68b47295ba688320991e7bde212fe5b0