### PR TITLE
feat: add personalized content player and settings

### DIFF
--- a/web/data/userPreferences.json
+++ b/web/data/userPreferences.json
@@ -1,0 +1,9 @@
+{
+  "favoriteTracks": [
+    "/calming-content/sample.mp3",
+    "/calming-content/relaxing-image.jpg"
+  ],
+  "jokes": [
+    "Why did the developer go broke? Because he used up all his cache."
+  ]
+}

--- a/web/public/calming-content/README.md
+++ b/web/public/calming-content/README.md
@@ -1,0 +1,2 @@
+This folder stores user-provided calming audio, video, or image files.
+Add media files here to make them available in the PersonalizedContentPlayer.

--- a/web/src/app/api/settings/route.ts
+++ b/web/src/app/api/settings/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
+
+const prefPath = path.join(process.cwd(), 'data', 'userPreferences.json');
+
+async function readPreferences() {
+  try {
+    const data = await fs.readFile(prefPath, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return { favoriteTracks: [], jokes: [] };
+  }
+}
+
+export async function GET() {
+  const prefs = await readPreferences();
+  return NextResponse.json(prefs);
+}

--- a/web/src/app/components/PersonalizedContentPlayer.tsx
+++ b/web/src/app/components/PersonalizedContentPlayer.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface PersonalizedContentPlayerProps {
+  queue: string[];
+}
+
+function getMediaType(url: string) {
+  const ext = url.split('.').pop()?.toLowerCase();
+  if (!ext) return 'unknown';
+  if (['mp3', 'wav', 'ogg'].includes(ext)) return 'audio';
+  if (['mp4', 'webm', 'ogg'].includes(ext)) return 'video';
+  if (['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'].includes(ext)) return 'image';
+  return 'unknown';
+}
+
+export default function PersonalizedContentPlayer({ queue }: PersonalizedContentPlayerProps) {
+  const [index, setIndex] = useState(0);
+  const current = queue[index];
+  const type = current ? getMediaType(current) : 'unknown';
+
+  const next = () => setIndex((i) => (i + 1) % queue.length);
+  const prev = () => setIndex((i) => (i - 1 + queue.length) % queue.length);
+
+  if (!current) return null;
+
+  return (
+    <div className="p-4 border rounded-md bg-background/80">
+      {type === 'audio' && (
+        <audio src={current} controls autoPlay onEnded={next} className="w-full" />
+      )}
+      {type === 'video' && (
+        <video src={current} controls autoPlay onEnded={next} className="w-full" />
+      )}
+      {type === 'image' && (
+        <img src={current} alt="calming content" className="mx-auto" />
+      )}
+      <div className="flex justify-between mt-2">
+        <button onClick={prev} aria-label="Previous" className="px-2 py-1 border rounded">
+          Prev
+        </button>
+        <span>
+          {index + 1} / {queue.length}
+        </span>
+        <button onClick={next} aria-label="Next" className="px-2 py-1 border rounded">
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/app/components/SettingsContext.tsx
+++ b/web/src/app/components/SettingsContext.tsx
@@ -16,6 +16,7 @@ interface Settings {
   theme: 'system' | 'light' | 'dark';
   reducedMotion: boolean;
   highContrast: boolean;
+  calmingContent: string[];
 }
 
 interface SettingsContextType {
@@ -35,6 +36,7 @@ const defaultSettings: Settings = {
   theme: 'system',
   reducedMotion: false,
   highContrast: false,
+  calmingContent: [],
 };
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);

--- a/web/src/app/components/SettingsPanel.tsx
+++ b/web/src/app/components/SettingsPanel.tsx
@@ -7,6 +7,19 @@ import { spacing, typography } from '@/design-system';
 export default function SettingsPanel() {
   const { settings, updateSettings } = useSettings();
   const [isOpen, setIsOpen] = useState(false);
+  const [newContent, setNewContent] = useState('');
+
+  const addContent = () => {
+    const item = newContent.trim();
+    if (item) {
+      updateSettings({ calmingContent: [...settings.calmingContent, item] });
+      setNewContent('');
+    }
+  };
+
+  const removeContent = (index: number) => {
+    updateSettings({ calmingContent: settings.calmingContent.filter((_, i) => i !== index) });
+  };
 
   return (
     <div className="fixed z-50" style={{ bottom: spacing.md, left: spacing.md }}>
@@ -130,6 +143,41 @@ export default function SettingsPanel() {
                     className="w-full"
                   />
                 </div>
+              </div>
+            </div>
+
+            {/* Calming Content Library */}
+            <div>
+              <h4 className="font-medium" style={{ marginBottom: spacing.sm }}>
+                Calming Content
+              </h4>
+              <ul className="space-y-1 mb-2">
+                {settings.calmingContent.map((item, idx) => (
+                  <li key={idx} className="flex items-center justify-between">
+                    <span className="break-all text-sm">{item}</span>
+                    <button
+                      onClick={() => removeContent(idx)}
+                      className="text-xs px-1 py-0.5 border rounded"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div className="flex space-x-2">
+                <input
+                  type="text"
+                  value={newContent}
+                  onChange={(e) => setNewContent(e.target.value)}
+                  className="flex-1 border rounded px-2 py-1 text-black"
+                  placeholder="/calming-content/file.mp3"
+                />
+                <button
+                  onClick={addContent}
+                  className="px-2 py-1 border rounded"
+                >
+                  Add
+                </button>
               </div>
             </div>
           </div>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -5,12 +5,14 @@ import { detectLoop, getAdvice } from "../lib/aiService";
 import { assessRisk } from "../lib/riskService";
 import { getManiaRisk } from "../lib/maniaService";
 import { spacing, typography, colors } from "@/design-system";
+import PersonalizedContentPlayer from "./components/PersonalizedContentPlayer";
 
 export default function Home() {
   const [text, setText] = useState("");
   const [steps, setSteps] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [crisis, setCrisis] = useState(false);
+  const [mediaQueue, setMediaQueue] = useState<string[]>([]);
 
   useEffect(() => {
     async function checkMania() {
@@ -18,6 +20,13 @@ export default function Home() {
         const risk = await getManiaRisk();
         if (risk > 0.7) {
           setCrisis(true);
+          try {
+            const res = await fetch('/api/settings');
+            const prefs = await res.json();
+            setMediaQueue(prefs.favoriteTracks || []);
+          } catch (err) {
+            console.error('Failed to load preferences', err);
+          }
           alert("Elevated mania risk detected. Support resources have been shown.");
         }
       } catch (e) {
@@ -93,6 +102,11 @@ export default function Home() {
             <li key={i}>{s}</li>
           ))}
         </ul>
+      )}
+      {crisis && mediaQueue.length > 0 && (
+        <div style={{ marginTop: spacing.lg }}>
+          <PersonalizedContentPlayer queue={mediaQueue} />
+        </div>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- add PersonalizedContentPlayer for calming media
- expose user preferences via /api/settings
- show personalized content when mania risk is high
- allow managing calming content library in settings panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b479b3852c83209b9e82d438d7fc48