### PR TITLE
feat: add proactive future simulations

### DIFF
--- a/web/src/app/api/simulate-future/route.ts
+++ b/web/src/app/api/simulate-future/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { Configuration, OpenAIApi } from "openai";
+import { requireAuth } from "@/lib/auth";
+
+const config = new Configuration({
+  apiKey: process.env.NEXT_PUBLIC_AZURE_OPENAI_KEY,
+  basePath: process.env.NEXT_PUBLIC_AZURE_OPENAI_ENDPOINT + "/openai/deployments/gpt-4",
+});
+
+const openai = new OpenAIApi(config);
+
+export async function POST(req: Request) {
+  const unauthorized = requireAuth(req);
+  if (unauthorized) return unauthorized;
+
+  try {
+    const { snapshot } = await req.json();
+
+    const completion = await openai.createChatCompletion({
+      model: "gpt-4",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a proactive planning agent. Given a repository snapshot, suggest potential future project branches. Respond in JSON array with objects {branch: string, summary: string, timeline: string[]}.",
+        },
+        { role: "user", content: snapshot },
+      ],
+    });
+
+    const text = completion.data.choices[0]?.message?.content || "[]";
+    return NextResponse.json(JSON.parse(text));
+  } catch (e) {
+    return NextResponse.json({ error: "Failed to simulate future states" }, { status: 500 });
+  }
+}

--- a/web/src/app/components/FutureSimulations.tsx
+++ b/web/src/app/components/FutureSimulations.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+import { FutureState } from '@/lib/proactiveAgent';
+
+interface Props {
+  simulations: FutureState[];
+  onClose: () => void;
+}
+
+export default function FutureSimulations({ simulations, onClose }: Props) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white text-black p-4 rounded max-w-lg max-h-full overflow-auto">
+        <h2 className="font-bold mb-2">Future Simulations</h2>
+        <div className="space-y-4">
+          {simulations.map(sim => (
+            <div key={sim.branch}>
+              <h3 className="font-semibold">{sim.branch}</h3>
+              <p className="text-sm mb-2">{sim.summary}</p>
+              <ol className="list-decimal pl-4 text-sm">
+                {sim.timeline.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+            </div>
+          ))}
+        </div>
+        <button
+          className="mt-4 bg-accent text-accent-foreground rounded px-4 py-2"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -4,8 +4,10 @@ import React, { useState, useEffect, useRef } from "react";
 import { detectLoop, getAdvice } from "../lib/aiService";
 import { assessRisk } from "../lib/riskService";
 import { getManiaRisk } from "../lib/maniaService";
+import { simulateFutureStates, FutureState } from "../lib/proactiveAgent";
 import { spacing, typography, colors } from "@/design-system";
 import PersonalizedContentPlayer from "./components/PersonalizedContentPlayer";
+import FutureSimulations from "./components/FutureSimulations";
 import { autosaveDraft, generateImprovedDraft } from "../lib/draftEnhancer";
 
 export default function Home() {
@@ -17,6 +19,8 @@ export default function Home() {
   const keystrokes = useRef(0);
   const [showRecover, setShowRecover] = useState(false);
   const [drafts, setDrafts] = useState<{original:{name:string;content:string}[];improved:{name:string;content:string}[]}>({original:[], improved:[]});
+  const [simulations, setSimulations] = useState<FutureState[]>([]);
+  const [showFuture, setShowFuture] = useState(false);
 
   useEffect(() => {
     async function checkMania() {
@@ -135,6 +139,22 @@ export default function Home() {
       >
         Recover Drafts
       </button>
+      <button
+        aria-label="Preview future"
+        className="bg-accent text-accent-foreground rounded hover:bg-accent/80 focus:outline-none focus:ring-2 focus:ring-ring"
+        style={{ padding: `${spacing.sm} ${spacing.md}`, marginBottom: spacing.md, marginLeft: spacing.sm }}
+        onClick={async () => {
+          try {
+            const sims = await simulateFutureStates('current repo snapshot');
+            setSimulations(sims);
+            setShowFuture(true);
+          } catch (err) {
+            console.error(err);
+          }
+        }}
+      >
+        Preview Future
+      </button>
       {error && (
         <p style={{ color: colors.danger, marginBottom: spacing.md }}>
           {error}
@@ -159,6 +179,9 @@ export default function Home() {
         <div style={{ marginTop: spacing.lg }}>
           <PersonalizedContentPlayer queue={mediaQueue} />
         </div>
+      )}
+      {showFuture && (
+        <FutureSimulations simulations={simulations} onClose={() => setShowFuture(false)} />
       )}
       {showRecover && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center">

--- a/web/src/lib/proactiveAgent.ts
+++ b/web/src/lib/proactiveAgent.ts
@@ -1,0 +1,21 @@
+export interface FutureState {
+  branch: string;
+  summary: string;
+  timeline: string[];
+}
+
+export async function simulateFutureStates(currentRepoSnapshot: string): Promise<FutureState[]> {
+  const response = await fetch("/api/simulate-future", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ snapshot: currentRepoSnapshot }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to simulate future states");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add proactiveAgent client with future state simulator
- support future state planning via /api/simulate-future endpoint
- visualize potential project branches with FutureSimulations component and Preview Future modal

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b48bd5cdf08320a03cdb2ff2173162