### PR TITLE
feat: add guided tutorials

### DIFF
--- a/tutorials/basic.json
+++ b/tutorials/basic.json
@@ -1,0 +1,16 @@
+{
+  "title": "Basic Task Tutorial",
+  "steps": [
+    {
+      "text": "Step one instruction.",
+      "image": "/images/step1.png",
+      "audio": "/audio/step1.mp3",
+      "warnings": ["Be careful"]
+    },
+    {
+      "text": "Step two instruction.",
+      "image": "/images/step2.png",
+      "warnings": ["Double-check settings"]
+    }
+  ]
+}

--- a/web/src/app/components/GuidedTutorial.tsx
+++ b/web/src/app/components/GuidedTutorial.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useState } from "react";
+
+export interface TutorialStep {
+  text: string;
+  image?: string;
+  audio?: string;
+  warnings?: string[];
+}
+
+export interface Tutorial {
+  title: string;
+  steps: TutorialStep[];
+}
+
+interface GuidedTutorialProps {
+  tutorial: Tutorial;
+  onFinish?: () => void;
+}
+
+const GuidedTutorial: React.FC<GuidedTutorialProps> = ({ tutorial, onFinish }) => {
+  const [index, setIndex] = useState(0);
+  const step = tutorial.steps[index];
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-white text-black p-4 rounded max-w-md w-full">
+        <h2 className="font-bold mb-2">{tutorial.title}</h2>
+        <p className="mb-2">{step.text}</p>
+        {step.image && (
+          <img src={step.image} alt={step.text} className="mb-2 max-w-full h-auto" />
+        )}
+        {step.audio && (
+          <audio controls src={step.audio} data-testid="audio" className="mb-2">
+            Your browser does not support the audio element.
+          </audio>
+        )}
+        {step.warnings && step.warnings.length > 0 && (
+          <ul className="list-disc pl-4 mb-2">
+            {step.warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        )}
+        <button
+          className="bg-accent text-accent-foreground rounded px-4 py-2"
+          onClick={() => {
+            if (index < tutorial.steps.length - 1) {
+              setIndex((i) => i + 1);
+            } else {
+              onFinish?.();
+            }
+          }}
+        >
+          {index < tutorial.steps.length - 1 ? "Next" : "Finish"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default GuidedTutorial;

--- a/web/src/app/components/__tests__/GuidedTutorial.test.tsx
+++ b/web/src/app/components/__tests__/GuidedTutorial.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import GuidedTutorial, { Tutorial } from '../GuidedTutorial';
+
+describe('GuidedTutorial', () => {
+  const tutorial: Tutorial = {
+    title: 'Test Tutorial',
+    steps: [
+      {
+        text: 'Step 1',
+        image: '/img1.png',
+        audio: '/audio1.mp3',
+        warnings: ['Be careful']
+      },
+      {
+        text: 'Step 2',
+        image: '/img2.png'
+      }
+    ]
+  };
+
+  it('navigates through steps and loads media', () => {
+    render(<GuidedTutorial tutorial={tutorial} />);
+
+    expect(screen.getByText('Step 1')).toBeInTheDocument();
+    const audio = screen.getByTestId('audio') as HTMLAudioElement;
+    expect(audio).toHaveAttribute('src', '/audio1.mp3');
+
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByText('Step 2')).toBeInTheDocument();
+    expect(screen.queryByTestId('audio')).toBeNull();
+  });
+});

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,8 @@ import { spacing, typography, colors } from "@/design-system";
 import PersonalizedContentPlayer from "./components/PersonalizedContentPlayer";
 import FutureSimulations from "./components/FutureSimulations";
 import { autosaveDraft, generateImprovedDraft } from "../lib/draftEnhancer";
+import GuidedTutorial, { Tutorial } from "./components/GuidedTutorial";
+import tutorialData from "../../../tutorials/basic.json";
 
 export default function Home() {
   const [text, setText] = useState("");
@@ -21,6 +23,8 @@ export default function Home() {
   const [drafts, setDrafts] = useState<{original:{name:string;content:string}[];improved:{name:string;content:string}[]}>({original:[], improved:[]});
   const [simulations, setSimulations] = useState<FutureState[]>([]);
   const [showFuture, setShowFuture] = useState(false);
+  const [showTutorial, setShowTutorial] = useState(false);
+  const tutorial: Tutorial = tutorialData as Tutorial;
 
   useEffect(() => {
     async function checkMania() {
@@ -62,6 +66,7 @@ export default function Home() {
   }, [crisis, text]);
 
   async function onCheck() {
+    if (showTutorial) return;
     setError(null);
     setSteps([]);
     setCrisis(false);
@@ -117,7 +122,10 @@ export default function Home() {
         aria-label="Improve draft"
         className="bg-secondary text-secondary-foreground rounded hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring"
         style={{ padding: `${spacing.sm} ${spacing.md}`, marginBottom: spacing.md, marginLeft: spacing.sm }}
-        onClick={() => generateImprovedDraft(text)}
+        onClick={() => {
+          if (showTutorial) return;
+          generateImprovedDraft(text);
+        }}
       >
         Improve Draft
       </button>
@@ -126,6 +134,7 @@ export default function Home() {
         className="bg-muted text-muted-foreground rounded hover:bg-muted/80 focus:outline-none focus:ring-2 focus:ring-ring"
         style={{ padding: `${spacing.sm} ${spacing.md}`, marginBottom: spacing.md, marginLeft: spacing.sm }}
         onClick={async () => {
+          if (showTutorial) return;
           try {
             const res = await fetch('/api/drafts');
             if (res.ok) {
@@ -144,6 +153,7 @@ export default function Home() {
         className="bg-accent text-accent-foreground rounded hover:bg-accent/80 focus:outline-none focus:ring-2 focus:ring-ring"
         style={{ padding: `${spacing.sm} ${spacing.md}`, marginBottom: spacing.md, marginLeft: spacing.sm }}
         onClick={async () => {
+          if (showTutorial) return;
           try {
             const sims = await simulateFutureStates('current repo snapshot');
             setSimulations(sims);
@@ -154,6 +164,14 @@ export default function Home() {
         }}
       >
         Preview Future
+      </button>
+      <button
+        aria-label="Toggle tutorial"
+        className="bg-muted text-muted-foreground rounded hover:bg-muted/80 focus:outline-none focus:ring-2 focus:ring-ring"
+        style={{ padding: `${spacing.sm} ${spacing.md}`, marginBottom: spacing.md, marginLeft: spacing.sm }}
+        onClick={() => setShowTutorial(s => !s)}
+      >
+        {showTutorial ? "Hide Tutorial" : "Show Tutorial"}
       </button>
       {error && (
         <p style={{ color: colors.danger, marginBottom: spacing.md }}>
@@ -207,6 +225,9 @@ export default function Home() {
             </button>
           </div>
         </div>
+      )}
+      {showTutorial && (
+        <GuidedTutorial tutorial={tutorial} onFinish={() => setShowTutorial(false)} />
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- add GuidedTutorial component for step-by-step guidance
- store tutorial definitions in `tutorials` directory
- integrate guided tutorial overlay into main page with toggle and action interception
- test tutorial navigation and media loading

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e1b0e4bc8320a865377a330010af

## Summary by Sourcery

Implement guided tutorials with JSON-defined steps and integrate overlay into the main page, including toggle controls and action blocking during tutorials.

New Features:
- Add GuidedTutorial React component supporting text, image, audio, and warnings per step
- Store tutorial definitions in a tutorials directory and load them into the app
- Integrate tutorial overlay into Home page with a toggle button and intercept other actions while active

Enhancements:
- Prevent main page actions from executing when the tutorial is active

Tests:
- Add unit tests for GuidedTutorial to verify step navigation, media rendering, and finish behavior