### PR TITLE
feat: add vector memory store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5738,6 +5738,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -6344,6 +6350,7 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "sql.js": "^1.13.0",
         "tailwind-merge": "^2.2.0"
       },
       "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "sql.js": "^1.13.0",
     "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {

--- a/web/src/app/api/brain/route.ts
+++ b/web/src/app/api/brain/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { storeEmbedding, searchEmbedding } from '@/lib/brain';
+
+export async function POST(req: NextRequest) {
+  const { text, metadata } = await req.json();
+  await storeEmbedding(text, metadata || {});
+  return NextResponse.json({ status: 'ok' });
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') || '';
+  const k = parseInt(searchParams.get('k') || '5', 10);
+  const results = await searchEmbedding(q, k);
+  return NextResponse.json(results);
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import { spacing, typography, colors } from "@/design-system";
 import PersonalizedContentPlayer from "./components/PersonalizedContentPlayer";
 import FutureSimulations from "./components/FutureSimulations";
 import { autosaveDraft, generateImprovedDraft } from "../lib/draftEnhancer";
+import { storeEmbedding } from "../lib/brain";
 import GuidedTutorial, { Tutorial } from "./components/GuidedTutorial";
 import tutorialData from "../../../tutorials/basic.json";
 
@@ -25,6 +26,7 @@ export default function Home() {
   const [showFuture, setShowFuture] = useState(false);
   const [showTutorial, setShowTutorial] = useState(false);
   const tutorial: Tutorial = tutorialData as Tutorial;
+  const userId = "demo-user";
 
   useEffect(() => {
     async function checkMania() {
@@ -54,6 +56,7 @@ export default function Home() {
     const interval = setInterval(() => {
       if (text) {
         autosaveDraft(text);
+        storeEmbedding(text, { timestamp: new Date().toISOString(), userId });
       }
     }, 10000);
     return () => clearInterval(interval);
@@ -70,6 +73,7 @@ export default function Home() {
     setError(null);
     setSteps([]);
     setCrisis(false);
+    await storeEmbedding(text, { timestamp: new Date().toISOString(), userId });
     try {
       const { score } = await assessRisk(text);
       if (score > 0.8) {
@@ -104,6 +108,7 @@ export default function Home() {
           keystrokes.current += 1;
           if (keystrokes.current >= 20) {
             autosaveDraft(e.target.value);
+            storeEmbedding(e.target.value, { timestamp: new Date().toISOString(), userId });
             keystrokes.current = 0;
           }
         }}

--- a/web/src/lib/__tests__/brain.test.ts
+++ b/web/src/lib/__tests__/brain.test.ts
@@ -1,0 +1,36 @@
+describe('brain', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.BRAIN_DB_PATH = `${process.cwd()}/test-${Math.random()}.db`;
+  });
+
+  afterEach(() => {
+    const p = process.env.BRAIN_DB_PATH as string;
+    if (require('fs').existsSync(p)) {
+      require('fs').unlinkSync(p);
+    }
+  });
+
+  it('stores and retrieves embeddings', async () => {
+    const { storeEmbedding, searchEmbedding } = await import('../brain');
+    await storeEmbedding('hello world', { userId: '1', timestamp: 't1' });
+    await storeEmbedding('goodbye world', { userId: '2', timestamp: 't2' });
+    const results = await searchEmbedding('hello', 1);
+    expect(results[0].text).toBe('hello world');
+    expect(results[0].metadata.userId).toBe('1');
+  });
+
+  it('returns empty array when no embeddings', async () => {
+    const { searchEmbedding } = await import('../brain');
+    const results = await searchEmbedding('none', 5);
+    expect(results).toEqual([]);
+  });
+
+  it('limits results to k', async () => {
+    const { storeEmbedding, searchEmbedding } = await import('../brain');
+    await storeEmbedding('a', {});
+    await storeEmbedding('b', {});
+    const results = await searchEmbedding('test', 1);
+    expect(results.length).toBe(1);
+  });
+});

--- a/web/src/lib/brain.ts
+++ b/web/src/lib/brain.ts
@@ -1,0 +1,89 @@
+import initSqlJs, { Database } from 'sql.js';
+import fs from 'fs';
+import path from 'path';
+
+let dbPromise: Promise<Database> | null = null;
+
+function getDbPath() {
+  return process.env.BRAIN_DB_PATH || path.join(process.cwd(), 'brain.db');
+}
+
+async function getDb(): Promise<Database> {
+  if (!dbPromise) {
+    dbPromise = (async () => {
+      const SQL = await initSqlJs({ locateFile: file => require.resolve('sql.js/dist/' + file) });
+      const dbPath = getDbPath();
+      if (fs.existsSync(dbPath)) {
+        const fileBuffer = fs.readFileSync(dbPath);
+        return new SQL.Database(fileBuffer);
+      }
+      return new SQL.Database();
+    })();
+  }
+  return dbPromise;
+}
+
+async function persistDb(db: Database) {
+  const dbPath = getDbPath();
+  if (dbPath === ':memory:') return;
+  const data = db.export();
+  const buffer = Buffer.from(data);
+  fs.writeFileSync(dbPath, buffer);
+}
+
+function embed(text: string): number[] {
+  const vec = [0, 0, 0];
+  for (let i = 0; i < text.length; i++) {
+    vec[i % 3] += text.charCodeAt(i);
+  }
+  const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+  return vec.map(v => v / norm);
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / ((Math.sqrt(na) * Math.sqrt(nb)) || 1);
+}
+
+export async function storeEmbedding(text: string, metadata: Record<string, any>) {
+  const db = await getDb();
+  db.run(`CREATE TABLE IF NOT EXISTS embeddings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text TEXT,
+    metadata TEXT,
+    vector TEXT
+  );`);
+  const vector = embed(text);
+  const stmt = db.prepare('INSERT INTO embeddings (text, metadata, vector) VALUES (?, ?, ?)');
+  stmt.run([text, JSON.stringify(metadata), JSON.stringify(vector)]);
+  stmt.free();
+  await persistDb(db);
+}
+
+export async function searchEmbedding(query: string, k: number) {
+  const db = await getDb();
+  db.run(`CREATE TABLE IF NOT EXISTS embeddings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text TEXT,
+    metadata TEXT,
+    vector TEXT
+  );`);
+  const qvec = embed(query);
+  const stmt = db.prepare('SELECT text, metadata, vector FROM embeddings');
+  const results: { text: string; metadata: any; score: number }[] = [];
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as any;
+    const vec = JSON.parse(row.vector);
+    const score = cosine(qvec, vec);
+    results.push({ text: row.text, metadata: JSON.parse(row.metadata), score });
+  }
+  stmt.free();
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, k);
+}
+


### PR DESCRIPTION
## Summary
- implement brain.ts with sql.js-backed storeEmbedding and searchEmbedding
- log user text in page.tsx to vector store on saves and checks
- add /api/brain endpoints for inserting and querying memories
- add unit tests for vector memory insert/search

## Testing
- `npm test --workspace web`

------
https://chatgpt.com/codex/tasks/task_e_68b5969235bc832089b704ac19c37cdf